### PR TITLE
Add kata-app build and deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ RUN go build -o main ./pkg/service/main.go
 # Use a lightweight base image for the final stage
 FROM alpine:latest
 
+RUN addgroup --system appgroup && adduser --system appuser --ingroup appgroup
+USER appuser
+
 # Set the working directory
 WORKDIR /app/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM golang:1.19-alpine AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+
+RUN go mod download
+
+COPY pkg/ ./pkg/
+
+# Build the application
+RUN go build -o main ./pkg/service/main.go
+
+# Use a lightweight base image for the final stage
+FROM alpine:latest
+
+# Set the working directory
+WORKDIR /app/
+
+# Copy the built binary from the builder stage
+COPY --from=builder /app/main .
+
+# Expose the default port
+EXPOSE 8000
+
+# Command to run the application
+CMD ["/app/main"]

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kata-app
+  namespace: kata-app
+  labels:
+    app: kata-app
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: kata-app
+  template:
+    metadata:
+      labels:
+        app: kata-app
+    spec:
+      containers:
+      - name: kata-app
+        image: kata-app:demo
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8000
+        env:
+        - name: KATA_SERVICE_ADDRESS
+          value: "0.0.0.0:8000"
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8000
+          initialDelaySeconds: 3
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8000
+          initialDelaySeconds: 3
+          periodSeconds: 5
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "512Mi"

--- a/service.yaml
+++ b/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kata-app-service
+  namespace: kata-app
+spec:
+  type: NodePort
+  ports:
+  - port: 8000
+    targetPort: 8000
+    nodePort: 30007 # Port exposed on the nodes
+  selector:
+    app: kata-app

--- a/testapp.md
+++ b/testapp.md
@@ -1,0 +1,15 @@
+The app can be tested using minikube cluster. Build the docker app locally
+
+- docker build -t kata-app:demo .
+
+Create namespace and deploy the app with service in minikube cluster
+
+- kubectl create ns kata-app
+- kubectl apply -f deployment.yaml
+- kubectl apply -f service.yaml
+
+Get minikube IP
+- minikube ip
+
+Then, access your app at:
+- http://<minikube-ip>:30007/

--- a/testapp.md
+++ b/testapp.md
@@ -12,4 +12,4 @@ Get minikube IP
 - minikube ip
 
 Then, access your app at:
-- http://<minikube-ip>:30007/
+- http://minikubeip:30007/

--- a/testapp.md
+++ b/testapp.md
@@ -13,3 +13,9 @@ Get minikube IP
 
 Then, access your app at:
 - http://minikubeip:30007/
+
+Improvements for production deployment:
+- Using HorizontalPodAutoscaler for app deployment to ensure app availability.
+- To monitor go app with prometheus, we should add following module
+  import "github.com/prometheus/client_golang/prometheus"
+- Define PodDisruptionBudget to ensure that few pods are available. 


### PR DESCRIPTION
### CHANGE
It includes Dockerfile, deployment.yaml, service.yaml and testapp.md(instructutions for local deployment)

### TEST

> Create namespace and deploy the app with service in minikube cluster

- kubectl create ns kata-app
- kubectl apply -f deployment.yaml
- kubectl apply -f service.yaml

> Get minikube IP

- minikube ip

> App should be accessible via:

- http://minikubeip:30007/`
